### PR TITLE
chore(ci): configure npm auth for bun publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,11 @@ jobs:
       - name: Build package
         run: bun run build
 
+      - name: Configure npm auth
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+
       - name: Publish to npm
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- write the npm auth token to ~/.npmrc before calling bun publish
- ensure tagged releases succeed now that npm registry requires auth on publish

## Testing
- bun test