### PR TITLE
chore(ci): improve npm publish diagnostics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,13 +32,20 @@ jobs:
       - name: Configure npm auth
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+          npm config set always-auth true
+
+      - name: Verify npm auth
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm whoami
 
       - name: Publish to npm
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --access public
+        run: bun publish --access public --log-level debug
 
       - name: Publish to JSR
         run: bunx jsr publish


### PR DESCRIPTION
## Summary
- set npm to always-auth and run rawriclark before publishing
- keep using bun publish but surface detailed logs when auth fails

## Testing
- not run (workflow-only change)