### PR TITLE
chore(ci): write npmrc with always-auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,8 +33,10 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-          npm config set always-auth true
+          cat <<'EOF' > ~/.npmrc
+          //registry.npmjs.org/:_authToken=${NPM_TOKEN}
+          always-auth=true
+          EOF
 
       - name: Verify npm auth
         env:


### PR DESCRIPTION
## Summary
- write the npm auth token and  directly into ~/.npmrc
- keep Bun publish flow with explicit npm whoami step for clearer diagnostics

## Testing
- not run (workflow-only change)