### PR TITLE
chore(ci): remove bun publish debug flag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --access public --log-level debug
+        run: bun publish --access public
 
       - name: Publish to JSR
         run: bunx jsr publish


### PR DESCRIPTION
## Summary
- drop the  option that Bun mis-parses as a tarball path
- keep npm auth verification that now succeeds

## Testing
- not run (workflow-only change)