### PR TITLE
chore(ci): switch publish step to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,9 +45,8 @@ jobs:
 
       - name: Publish to npm
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: bun publish --access public
+        run: npm publish --access public
 
       - name: Publish to JSR
         run: bunx jsr publish


### PR DESCRIPTION
## Summary
- keep Bun for build/test but call 
> @saibdev/dexter@6.0.1 prepublishOnly
> bun test

bun test v1.2.22 (6bafe260)

> @saibdev/dexter@6.0.1 prepare
> bun run build

+ @saibdev/dexter@6.0.1 instead of bun publish
- rely on NODE_AUTH_TOKEN so npm handles auth cleanly

## Testing
- not run (workflow-only change)