### PR TITLE
chore(ci): expand npm token in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          cat <<'EOF' > ~/.npmrc
+          cat <<EOF > ~/.npmrc
           //registry.npmjs.org/:_authToken=${NPM_TOKEN}
           always-auth=true
           EOF


### PR DESCRIPTION
## Summary
- remove strong quoting from the npmrc heredoc so  is expanded
- this ensures the publish step gets a real token instead of the literal string

## Testing
- not run (workflow-only change)