### PR TITLE
chore(ci): temporarily disable JSR publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,5 +53,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access public
 
-      - name: Publish to JSR
-        run: bunx jsr publish
+      # Temporarily skip JSR publishing until import specifiers are Deno-compatible
+      #- name: Publish to JSR
+      #  run: bunx jsr publish


### PR DESCRIPTION
## Summary
- comment out the JSR publish step so our release workflow stops failing on import resolution errors
- keep npm publish intact while we sort out Deno-compatible imports

## Testing
- not run (workflow-only change)