### PR TITLE
chore(release): bump version to 6.0.3

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@saibdev/dexter",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saibdev/dexter",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "license": "MIT",
   "author": {
     "name": "Clark Alesna",


### PR DESCRIPTION
## Summary
- bump package and jsr versions to 6.0.3 to re-run the publish workflow without JSR

## Testing
- bun test