### PR TITLE
chore(release): bump version to 6.0.4

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@saibdev/dexter",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saibdev/dexter",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "license": "MIT",
   "author": {
     "name": "Clark Alesna",


### PR DESCRIPTION
## Summary
- bump package metadata to v6.0.4 so we can ship the latest inline datum fix
- align jsr and npm manifests for the release

## Testing
- not run (metadata-only change)
